### PR TITLE
Fixed issue 167

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -286,6 +286,9 @@ function StepZilla(props) {
 
 
   var renderSteps = function renderSteps() {
+    var pointerEventsNone = {
+      pointerEvents: 'none'
+    };
     return props.steps.map(function (s, i) {
       return _react.default.createElement("li", {
         className: getClassName('progtrckr', i),
@@ -294,7 +297,11 @@ function StepZilla(props) {
         },
         key: i,
         value: i
-      }, _react.default.createElement("em", null, i + 1), _react.default.createElement("span", null, props.steps[i].name));
+      }, _react.default.createElement("em", {
+        style: pointerEventsNone
+      }, i + 1), _react.default.createElement("span", {
+        style: pointerEventsNone
+      }, props.steps[i].name));
     });
   };
 

--- a/src/main.js
+++ b/src/main.js
@@ -261,10 +261,11 @@ export default function StepZilla(props) {
 
   // render the steps as stepsNavigation
   const renderSteps = () => {
+    const pointerEventsNone = { pointerEvents: 'none' };
     return props.steps.map((s, i) => (
       <li className={getClassName('progtrckr', i)} onClick={(evt) => { jumpToStep(evt); }} key={i} value={i}>
-          <em>{i + 1}</em>
-          <span>{props.steps[i].name}</span>
+          <em style={pointerEventsNone}>{i + 1}</em>
+          <span style={pointerEventsNone}>{props.steps[i].name}</span>
       </li>
     ));
   };


### PR DESCRIPTION
### Issue 167

This pull request attend to fix the [issue 167](https://github.com/newbreedofgeek/react-stepzilla/issues/167).

The subject of the issue was the non-functionality of the Top Navigation elements. When we clicked on the Steps, the app where returning us `undefined` and we were not changing the current step.

The bug was there because when we clicked on Steps, it was not the `<li/>` elements that were trigger (the element where the `jumpToStep` function is called but it was its children (`<em/>` and `<span/>`).

In order to fix this I've added an inline style property `pointer-events: none;` to each of the children of the `<li/>` element.

This way when we click on the `<Step/>` it's always the `<li/>` element which is trigger, so the `jumpToStep` is called and StepZilla works correctly.
﻿
